### PR TITLE
Better View Ripples

### DIFF
--- a/Material/Components/Button/ButtonDrawable.cs
+++ b/Material/Components/Button/ButtonDrawable.cs
@@ -16,15 +16,14 @@ internal class ButtonDrawable(Button view) : IDrawable
         canvas.DrawOutline(this.view, rect);
         canvas.DrawOverlayLayer(this.view, rect);
 
-        if (this.view.RipplePercent is 0f or 1f)
-            canvas.DrawStateLayer(this.view, rect, this.view.ViewState);
-        else
+        for (var rippleIndex = 0; rippleIndex < this.view.Ripples.Count; rippleIndex++)
+        {
             canvas.DrawRipple(
                 this.view,
                 this.view.LastTouchPoint,
-                this.view.RippleSize,
-                this.view.RipplePercent
+                this.view.Ripples[rippleIndex]
             );
+        }
 
         var scale = rect.Height / 40f;
         canvas.DrawIcon(

--- a/Material/Components/CheckBox/CheckBoxDrawable.cs
+++ b/Material/Components/CheckBox/CheckBoxDrawable.cs
@@ -30,15 +30,14 @@ internal class CheckBoxDrawable(CheckBox view) : IDrawable
         drawRect.AppendCircle(rect.Center.X, rect.Center.Y, Math.Max(rect.Width, rect.Height) / 2f);
         canvas.ClipPath(drawRect);
 
-        if (view.RipplePercent is 0f or 1f)
-            canvas.DrawStateLayer(view, rect, view.ViewState);
-        else
+        for (var rippleIndex = 0; rippleIndex < view.Ripples.Count; rippleIndex++)
+        {
             canvas.DrawRipple(
                 view,
                 view.LastTouchPoint,
-                view.RippleSize,
-                view.RipplePercent
+                view.Ripples[rippleIndex]
             );
+        }
 
         canvas.RestoreState();
     }

--- a/Material/Components/Chip/ChipDrawable.cs
+++ b/Material/Components/Chip/ChipDrawable.cs
@@ -24,15 +24,14 @@ internal class ChipDrawable(Chip view) : IDrawable, IDisposable
             18f * scale
         );
 
-        if (view.RipplePercent is 0f or 1f)
-            canvas.DrawStateLayer(view, rect, view.ViewState);
-        else
+        for (var rippleIndex = 0; rippleIndex < view.Ripples.Count; rippleIndex++)
+        {
             canvas.DrawRipple(
                 view,
                 view.LastTouchPoint,
-                view.RippleSize,
-                view.RipplePercent
+                view.Ripples[rippleIndex]
             );
+        }
 
         canvas.DrawIcon(
             view,

--- a/Material/Components/ComboBox/ComboBox.cs
+++ b/Material/Components/ComboBox/ComboBox.cs
@@ -319,7 +319,7 @@ public class ComboBox
         return 0f;
     }
 
-    protected override void StartRippleEffect()
+    protected override void StartRippleEffect(Ripple ripple)
     {
         return;
     }

--- a/Material/Components/ContextMenu/MenuItemDrawable.cs
+++ b/Material/Components/ContextMenu/MenuItemDrawable.cs
@@ -7,17 +7,15 @@ internal class MenuItemDrawable(MenuItem view) : IDrawable
         canvas.SaveState();
         canvas.Antialias = true;
         canvas.ClipRectangle(rect);
-
-        if (view.RipplePercent is 0f or 1f)
-            canvas.DrawStateLayer(view, rect, view.ViewState);
-        else
+        
+        for (var rippleIndex = 0; rippleIndex < view.Ripples.Count; rippleIndex++)
+        {
             canvas.DrawRipple(
                 view,
                 view.LastTouchPoint,
-                view.RippleSize,
-                view.RipplePercent
+                view.Ripples[rippleIndex]
             );
-
+        }
         canvas.DrawIcon(view, new RectF(12f, 12f, 24f, 24f), 24, 1f);
 
         var iconSize = !string.IsNullOrEmpty(view.IconData) ? 24f : 0f;

--- a/Material/Components/FAB/ExtendedFABDrawable.cs
+++ b/Material/Components/FAB/ExtendedFABDrawable.cs
@@ -11,15 +11,14 @@ internal class ExtendedFABDrawable(ExtendedFAB view) : IDrawable
         canvas.DrawBackground(view, rect);
         canvas.DrawOverlayLayer(view, rect);
 
-        if (view.RipplePercent is 0f or 1f)
-            canvas.DrawStateLayer(view, rect, view.ViewState);
-        else
+        for (var rippleIndex = 0; rippleIndex < view.Ripples.Count; rippleIndex++)
+        {
             canvas.DrawRipple(
                 view,
                 view.LastTouchPoint,
-                view.RippleSize,
-                view.RipplePercent
+                view.Ripples[rippleIndex]
             );
+        }
 
         var scale = rect.Height / 56f;
         canvas.DrawIcon(

--- a/Material/Components/FAB/FABDrawable.cs
+++ b/Material/Components/FAB/FABDrawable.cs
@@ -11,15 +11,14 @@ internal class FABDrawable(FAB view) : IDrawable
         canvas.DrawBackground(view, rect);
         canvas.DrawOverlayLayer(view, rect);
 
-        if (view.RipplePercent is 0f or 1f)
-            canvas.DrawStateLayer(view, rect, view.ViewState);
-        else
+        for (var rippleIndex = 0; rippleIndex < view.Ripples.Count; rippleIndex++)
+        {
             canvas.DrawRipple(
                 view,
                 view.LastTouchPoint,
-                view.RippleSize,
-                view.RipplePercent
+                view.Ripples[rippleIndex]
             );
+        }
 
         var scale = rect.Height / 56f;
         canvas.DrawIcon(

--- a/Material/Components/IconButton/IconButtonDrawable.cs
+++ b/Material/Components/IconButton/IconButtonDrawable.cs
@@ -15,15 +15,14 @@ class IconButtonDrawable(IconButton view) : IDrawable
         canvas.DrawIcon(view, rect, 24, scale);
         canvas.DrawOverlayLayer(view, rect);
 
-        if (view.RipplePercent is 0f or 1f)
-            canvas.DrawStateLayer(view, rect, view.ViewState);
-        else
+        for (var rippleIndex = 0; rippleIndex < view.Ripples.Count; rippleIndex++)
+        {
             canvas.DrawRipple(
                 view,
                 view.LastTouchPoint,
-                view.RippleSize,
-                view.RipplePercent
+                view.Ripples[rippleIndex]
             );
+        }
 
         canvas.ResetState();
     }

--- a/Material/Components/NavigationBar/NavigationBarItemDrawable.cs
+++ b/Material/Components/NavigationBar/NavigationBarItemDrawable.cs
@@ -40,10 +40,14 @@ internal class NavigationBarItemDrawable(NavigationBarItem view) : IDrawable
             canvas.FillRectangle(rect);
         }
 
-        if (view.RipplePercent is 0f or 1f)
-            canvas.DrawStateLayer(view, bounds, view.ViewState);
-        else
-            canvas.DrawRipple(view, view.rippleStartPoint, view.RippleSize, view.RipplePercent);
+        for (var rippleIndex = 0; rippleIndex < view.Ripples.Count; rippleIndex++)
+        {
+            canvas.DrawRipple(
+                view,
+                view.LastTouchPoint,
+                view.Ripples[rippleIndex]
+            );
+        }
 
         canvas.ResetState();
     }

--- a/Material/Components/NavigationDrawer/NavigationDrawerItemDrawable.cs
+++ b/Material/Components/NavigationDrawer/NavigationDrawerItemDrawable.cs
@@ -13,15 +13,14 @@ internal class NavigationDrawerItemDrawable(NavigationDrawerItem view) : IDrawab
 
         canvas.DrawBackground(this.view, rect);
 
-        if (this.view.RipplePercent is 0f or 1f)
-            canvas.DrawStateLayer(this.view, rect, this.view.ViewState);
-        else
+        for (var rippleIndex = 0; rippleIndex < view.Ripples.Count; rippleIndex++)
+        {
             canvas.DrawRipple(
-                this.view,
-                this.view.LastTouchPoint,
-                this.view.RippleSize,
-                this.view.RipplePercent
+                view,
+                view.LastTouchPoint,
+                view.Ripples[rippleIndex]
             );
+        }
 
         canvas.DrawIcon(
            this.view,

--- a/Material/Components/SegmentedButton/SegmentedButtonDrawable.cs
+++ b/Material/Components/SegmentedButton/SegmentedButtonDrawable.cs
@@ -1,4 +1,6 @@
-﻿namespace Material;
+﻿using Material.Extensions;
+
+namespace Material;
 
 internal class SegmentedButtonDrawable(SegmentedButton view) : IDrawable, IDisposable
 {
@@ -53,19 +55,24 @@ internal class SegmentedButtonDrawable(SegmentedButton view) : IDrawable, IDispo
         this.ClipItemRect(canvas, rect, item);
         canvas.DrawBackground(item, rect);
 
-        if (
-            rect.Contains(view.LastTouchPoint)
-            && item.ViewState is ViewState.Hovered or ViewState.Pressed
-            && view.RipplePercent is not 0f or 1f
-        )
+        foreach (var ripple in view.Ripples)
             canvas.DrawRipple(
                 view,
                 view.LastTouchPoint,
-                view.RippleSize / 3,
-                view.RipplePercent
+                ripple.Size /3,
+                ripple.Percent,
+                ripple.Alpha
             );
-        else
-            canvas.DrawStateLayer(item, rect, item.ViewState);
+        for (var rippleIndex = 0; rippleIndex < view.Ripples.Count; rippleIndex++)
+        {
+            canvas.DrawRipple(
+                view,
+                view.LastTouchPoint,
+                view.Ripples[rippleIndex].Size/3,
+                view.Ripples[rippleIndex].Percent,
+                view.Ripples[rippleIndex].Alpha
+            );
+        }
 
         var scale = rect.Height / 40f;
         var textSize = view.GetStringSize(item.Text);

--- a/Material/Components/Tabs/TabItemDrawable.cs
+++ b/Material/Components/Tabs/TabItemDrawable.cs
@@ -10,10 +10,14 @@ internal class TabItemDrawable(TabItem view) : IDrawable
         canvas.ClipPath(view.GetClipPath(rect));
         canvas.DrawBackground(view, rect);
 
-        if (view.RipplePercent is 0f or 1f)
-            canvas.DrawStateLayer(view, rect, view.ViewState);
-        else
-            canvas.DrawRipple(view, view.LastTouchPoint, view.RippleSize, view.RipplePercent);
+        for (var rippleIndex = 0; rippleIndex < view.Ripples.Count; rippleIndex++)
+        {
+            canvas.DrawRipple(
+                view,
+                view.LastTouchPoint,
+                view.Ripples[rippleIndex]
+            );
+        }
 
         //#if ANDROID
         //        canvas.Scale(canvas.DisplayScale, canvas.DisplayScale);

--- a/Material/Components/TextField/TextField.cs
+++ b/Material/Components/TextField/TextField.cs
@@ -437,7 +437,7 @@ public class TextField
         return maxSize;
     }
 
-    protected override void StartRippleEffect()
+    protected override void StartRippleEffect(Ripple ripple)
     {
         var x = this.LastTouchPoint.X + this.Bounds.Left;
         var y = this.LastTouchPoint.Y + this.Bounds.Top;
@@ -458,7 +458,7 @@ public class TextField
                 new Microsoft.Maui.Animations.Animation(
                     callback: (progress) =>
                     {
-                        this.RipplePercent = 0f.Lerp(1f, progress);
+                        ripple.Percent = 0f.Lerp(1f, progress);
                         this.Invalidate();
                     },
                     duration: this.RippleDuration,

--- a/Material/Components/TextField/TextFieldDrawable.cs
+++ b/Material/Components/TextField/TextFieldDrawable.cs
@@ -195,13 +195,14 @@ internal class TextFieldDrawable(TextField view) : IDrawable
         drawRect.AppendCircle(rect.Right - 24f, rect.Center.Y, 20f);
         canvas.ClipPath(drawRect);
 
-        if (view.RipplePercent is not 0f and not 1f)
+        for (var rippleIndex = 0; rippleIndex < view.Ripples.Count; rippleIndex++)
+        {
             canvas.DrawRipple(
                 view,
                 view.LastTouchPoint,
-                view.RippleSize,
-                view.RipplePercent
+                view.Ripples[rippleIndex]
             );
+        }
 
         canvas.RestoreState();
     }

--- a/Material/Extensions/CanvasExtension.cs
+++ b/Material/Extensions/CanvasExtension.cs
@@ -140,11 +140,27 @@ internal static class CanvasExtension
         IRippleElement element,
         PointF point,
         float size,
-        float percent
+        float percent,
+        float alpha = 1f
     )
     {
-        canvas.FillColor = element.StateLayerColor.WithAlpha(StateLayerOpacity.Pressed);
+        if (percent <= 0f || alpha <= 0f)
+            return;
+        canvas.FillColor = element.StateLayerColor.WithAlpha(StateLayerOpacity.Pressed).MultiplyAlpha(alpha);
         canvas.FillCircle(point, 0f.Lerp(size, percent));
+    }
+
+    internal static void DrawRipple(
+        this ICanvas canvas,
+        IRippleElement element,
+        PointF point,
+        Ripple ripple
+    )
+    {
+        if (ripple.Percent <= 0f || ripple.Alpha <= 0f)
+            return;
+        canvas.FillColor = element.StateLayerColor.WithAlpha(StateLayerOpacity.Pressed).MultiplyAlpha(ripple.Alpha);
+        canvas.FillCircle(point, 0f.Lerp(ripple.Size, ripple.Percent));
     }
 
     internal static void DrawText<TElement>(

--- a/Material/Primitives/Ripple.cs
+++ b/Material/Primitives/Ripple.cs
@@ -1,0 +1,9 @@
+﻿namespace Material.Primitives;
+public class Ripple
+{
+    public float Size { get; set; }
+    public float Percent { get; set; }
+    public float Alpha { get; set; } = 1f;
+
+    public readonly TaskCompletionSource RippleFinished = new();
+}

--- a/Material/Primitives/StackLayers.cs
+++ b/Material/Primitives/StackLayers.cs
@@ -1,0 +1,133 @@
+﻿using System.Collections;
+
+namespace Material.Primitives;
+/// <summary>
+/// 
+/// </summary>
+/// <typeparam name="T"></typeparam>
+/// <param name="max">Maximum of overlapping layers</param>
+public class StackLayers<T>(int max = 4) : IEnumerable<T>
+{
+    internal readonly List<T> layers = [];
+    internal readonly int max = max;
+
+    /// <summary>
+    /// Pops up the first layer.
+    /// </summary>
+    /// <returns>true if success; false if empty.</returns>
+    public bool Pop()
+    {
+        try
+        {
+            layers.RemoveAt(0);
+            return true;
+        }
+        catch (ArgumentOutOfRangeException) { return false; }
+    }
+
+    /// <summary>
+    /// Pops up the layer in layers with given layer.
+    /// </summary>
+    /// <param name="layer"></param>
+    /// <returns>true if layer is successfully removed; false if layer not found in layers.</returns>
+    public bool Pop(T layer) => layers.Remove(layer);
+
+    /// <summary>  
+    /// Attempts to pop the first layer of type <typeparamref name="T"/> from a collection.  
+    /// It invokes a delegate function <paramref name="onPop"/> with the layer as an argument.  
+    /// If the delegate returns <c>true</c>, the pop operation is cancelled and the method returns <c>false</c>.  
+    /// If the delegate returns <c>false</c>, the layer is popped from the collection and the method returns <c>true</c>.  
+    /// If the collection is empty, the method returns <c>false</c> without invoking the delegate.  
+    /// </summary>  
+    /// <param name="onPop">A delegate function that takes a layer of type <typeparamref name="T"/> and returns a boolean.  
+    /// It determines whether the pop operation should proceed based on the layer's properties or conditions.</param>  
+    /// <returns><c>true</c> if the layer was successfully popped; <c>false</c> if the collection was empty or the pop operation was cancelled.</returns>  
+    public bool Pop(Func<T, bool> onPop)
+    {
+        try
+        {
+            var layer = layers.ElementAt(0);
+            var cancel = onPop(layer);
+
+            if (cancel)
+                return false;
+
+            layers.RemoveAt(0);
+            return true;
+        }
+        catch (ArgumentOutOfRangeException) { return false; }
+    }
+
+    /// <summary>
+    /// Keep popping up the first layer until there is free space to push.
+    /// </summary>
+    internal void PopForFree()
+    {
+        while (layers.Count >= max)
+            this.Pop();
+    }
+
+    /// <summary>
+    /// Keep popping up the first layer until there is free space to push.
+    /// </summary>
+    /// <param name="onPop">A delegate function that takes a layer of type <typeparamref name="T"/> and returns a boolean.  
+    /// It determines whether the pop operation should proceed based on the layer's properties or conditions.</param>  
+    internal void PopForFree(Func<T, bool> onPop)
+    {
+        while (layers.Count >= max)
+            this.Pop(onPop);
+    }
+
+    /// <summary>
+    /// Pushes the layer to the end.
+    /// </summary>
+    /// <param name="layer">The specified layer to push.</param>
+    public void Push(T layer)
+    {
+        this.PopForFree();
+
+        layers.Add(layer);
+    }
+
+    /// <summary>
+    /// Pushes the layer to the end.
+    /// </summary>
+    /// <param name="layer">The specified layer to push.</param>
+    /// <param name="onPop">A delegate function that takes a layer of type <typeparamref name="T"/> and returns a boolean.  
+    /// It determines whether the pop operation should proceed based on the layer's properties or conditions.</param>  
+    public void Push(T layer, Func<T, bool> onPop)
+    {
+        this.PopForFree(onPop);
+
+        layers.Add(layer);
+    }
+
+    /// <summary>
+    /// Pops up all layers.
+    /// </summary>
+    public void Clear()
+    {
+        layers.Clear();
+    }
+
+    /// <summary>
+    /// Pops up all layers.
+    /// </summary>
+    /// <param name="onPop">A delegate function that takes a layer of type <typeparamref name="T"/> and returns a boolean.  
+    /// It determines whether the pop operation should proceed based on the layer's properties or conditions.</param>  
+    public void Clear(Func<T, bool> onPop)
+    {
+        for (var i = 0; i < layers.Count; i++)
+            if (!onPop(layers[i])) layers.Remove(layers[i]);
+    }
+
+    public IReadOnlyList<T> Layers => layers.AsReadOnly();
+    public int Count => layers.Count;
+
+    public T this[int index] => layers[index];
+
+    public IEnumerator<T> GetEnumerator() => ((IEnumerable<T>)this.layers).GetEnumerator();
+
+    IEnumerator IEnumerable.GetEnumerator() => ((IEnumerable)this.layers).GetEnumerator();
+
+}


### PR DESCRIPTION
### 📄 Description

I've strived to make the controls with Ripple effect as perfect as possible, to align them more closely with Material Design guidelines. 

### 🗃️ Alternative solutions

Now, the Ripple Effect enables multiple Ripples to be displayed within a single View (with the maximum number limited by the `MaxRippleLayers` variable). Each Ripple will fade in during  `OnStartInteraction` and fade out during `OnEndInteraction`. Of course, to achieve this, I had to make some compromises in terms of existing features. For instance, instead of checking the value of the `RipplePercent` variable for each View during drawing and potentially calling `canvas.DrawStateLayer`, I now directly and consistently call `canvas.DrawRipple`. To this end, I've optimized the `DrawRipple` extension method: if `ripplePercent` or `rippleAlpha` is less than or equal to 0, the function call will immediately return, improving efficiency.

### ✅ Tasks
<!--Give an overview of all the specific things you would like to be changed or implemented.
If an issue already exists with this, you can add the issue link or number-->

..
<!--
```[tasklist]
### High Priority
- [ ] Something
- [ ] Another thing
- [ ] https://github.com/link/to/an/issue
```
```[tasklist]
### Nice to have
- [ ] Something
- [ ] Another thing
- [ ] https://github.com/link/to/an/issue
```
-->

### 📸 Assets

Screen Record on Android:

https://github.com/user-attachments/assets/73e4e1d4-71d8-4e27-835a-0463ec3ff33b

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Enhance the ripple effect system to support multiple ripple layers per view, improving visual feedback and aligning with Material Design guidelines. Introduce a new `StackLayers` class to manage ripple layers efficiently, and optimize the ripple drawing process for better performance.

New Features:
- Introduce a new ripple effect system that allows multiple ripple layers to be displayed within a single view, enhancing the visual feedback in line with Material Design guidelines.

Enhancements:
- Optimize the ripple drawing process by directly calling `canvas.DrawRipple` instead of checking `RipplePercent` for each view, improving efficiency.
- Add a `StackLayers` class to manage overlapping ripple layers, ensuring efficient handling of multiple ripple effects.

<!-- Generated by sourcery-ai[bot]: end summary -->